### PR TITLE
Fixing missing string resources issue

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="coming_soon_btn">Coming Soon</string>
     <string name="downloads_btn">Downloads</string>
     <string name="more_btn">More</string>
-    <!-- TODO: Remove or change this placeholder text -->
+    <string name="toolbar_tvshows">TV Shows</string>
+    <string name="toolbar_movies">Movies</string>
+    <string name="home_my_list">My List</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
# Fixes: Replaced missing string resources referenced in [home_page_toolbar](https://github.com/Eronred/NetflixClone/blob/development/app/src/main/res/layout/home_page_toolbar.xml)

## Changes: 
### Added string resources:
- toolbar_tvshows
- toolbar_movies
- home_my_list